### PR TITLE
fix: EOF on DB update deleted proposal from chain

### DIFF
--- a/database/gov.go
+++ b/database/gov.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/cosmos/cosmos-sdk/codec"
-	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	govtypesv1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
 	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
 	"github.com/lib/pq"
@@ -131,7 +130,9 @@ INSERT INTO proposal(
 
 // GetProposal returns the proposal with the given id, or nil if not found
 func (db *Db) GetProposal(id uint64) (types.Proposal, error) {
+	var proposal types.Proposal
 	var rows []*dbtypes.ProposalRow
+
 	err := db.SQL.Select(&rows, `SELECT * FROM proposal WHERE id = $1`, id)
 	if err != nil {
 		return types.Proposal{}, err
@@ -142,34 +143,11 @@ func (db *Db) GetProposal(id uint64) (types.Proposal, error) {
 	}
 
 	row := rows[0]
+	proposal.ID = row.ProposalID
+	proposal.Status = row.Status
+	proposal.VotingStartTime = dbtypes.NullTimeToTime(row.VotingStartTime)
+	proposal.VotingEndTime = dbtypes.NullTimeToTime(row.VotingEndTime)
 
-	trimContent := strings.TrimPrefix(row.Content, "{")
-	trimContent = strings.TrimPrefix(trimContent, "}")
-	jsonMessages := strings.Split(trimContent, ",")
-
-	var messages []*codectypes.Any
-	for _, jsonMessage := range jsonMessages {
-		var msg codectypes.Any
-		err = db.Cdc.UnmarshalJSON([]byte(jsonMessage), &msg)
-		if err != nil {
-			return types.Proposal{}, err
-		}
-		messages = append(messages, &msg)
-	}
-
-	proposal := types.NewProposal(
-		row.ProposalID,
-		row.Title,
-		row.Description,
-		row.Metadata,
-		messages,
-		row.Status,
-		row.SubmitTime,
-		row.DepositEndTime,
-		dbtypes.NullTimeToTime(row.VotingStartTime),
-		dbtypes.NullTimeToTime(row.VotingEndTime),
-		row.Proposer,
-	)
 	return proposal, nil
 }
 

--- a/modules/gov/utils_proposal.go
+++ b/modules/gov/utils_proposal.go
@@ -82,17 +82,17 @@ func (m *Module) UpdateProposalStakingPoolSnapshot(height int64, blockVals *tmct
 // updateDeletedProposalStatus updates the proposal having the given id by setting its status
 // to the one that represents a deleted proposal
 func (m *Module) updateDeletedProposalStatus(id uint64) error {
-	stored, err := m.db.GetProposal(id)
+	proposalForUpdate, err := m.db.GetProposalForUpdate(id)
 	if err != nil {
 		return err
 	}
 
 	return m.db.UpdateProposal(
 		types.NewProposalUpdate(
-			stored.ID,
+			proposalForUpdate.ProposalID,
 			types.ProposalStatusInvalid,
-			stored.VotingStartTime,
-			stored.VotingEndTime,
+			proposalForUpdate.VotingStartTime,
+			proposalForUpdate.VotingEndTime,
 		),
 	)
 }


### PR DESCRIPTION
The governance GetProposal only caller -> updateDeletedProposalStatus method, requires only a few properties from the found as existing in the DB proposal, so all the JSON messages voodoo magic tricks to just create a brand new proposal object, then not use it at all, but break, are not really needed.