### PR TITLE
Update gce cloudsql-proxy from 1.11 to 1.33.15

### DIFF
--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -55,7 +55,7 @@ services:
       HASURA_ACTIONS_RPC: ${HASURA_ACTIONS_RPC}
   cloudsql-proxy:
     container_name: cloudsql-proxy
-    image: gcr.io/cloudsql-docker/gce-proxy:1.11
+    image: gcr.io/cloudsql-docker/gce-proxy:1.33.15
     command: /cloud_sql_proxy --dir=/cloudsql -instances=${GCLOUD_INSTANCE_CONNECTION_NAME}=tcp:0.0.0.0:5432
     ports:
       - 5432:5432


### PR DESCRIPTION
Updated cloudsql-proxy from 1.11 to 1.33.15

Manually tested